### PR TITLE
Update Webstorm version to 2016.2.2

### DIFF
--- a/Formula/webstorm.rb
+++ b/Formula/webstorm.rb
@@ -1,7 +1,7 @@
 class Webstorm < Formula
     desc "The smartest JavaScript IDE."
     homepage "http://www.jetbrains.com/webstorm/"
-    version "2016.2"
+    version "2016.2.2"
     url "https://download.jetbrains.com/webstorm/WebStorm-#{version}.tar.gz"
     sha256 "a3453ce89f6dfc55de1723b3e6119a71771a20a8c4ca4da60dcb1fd91e3700d9"
 

--- a/Formula/webstorm.rb
+++ b/Formula/webstorm.rb
@@ -3,7 +3,7 @@ class Webstorm < Formula
     homepage "http://www.jetbrains.com/webstorm/"
     version "2016.2.2"
     url "https://download.jetbrains.com/webstorm/WebStorm-#{version}.tar.gz"
-    sha256 "a3453ce89f6dfc55de1723b3e6119a71771a20a8c4ca4da60dcb1fd91e3700d9"
+    sha256 "06af83ee181b37ae0a1108b4b88ae9a8d10f153796f3c59c879a4ead24dc4e58"
 
     bottle :unneeded
 


### PR DESCRIPTION
The 2016.2 version appears to have stopped working. 
https://download.jetbrains.com/webstorm/WebStorm-2016.2.tar.gz gives a 403 error
