### PR TITLE
Remove trailing slashes in shadowsocks go server

### DIFF
--- a/Formula/shadowsocks-go-server-binary.rb
+++ b/Formula/shadowsocks-go-server-binary.rb
@@ -9,7 +9,7 @@ class ShadowsocksGoServerBinary < Formula
     bottle :unneeded
 
     def install
-        libexec.install Dir["*"]\
-        bin.install("#{libexec}/shadowsocks-server-linux64-#{version}" => "ssgo_server")\
+        libexec.install Dir["*"]
+        bin.install("#{libexec}/shadowsocks-server-linux64-#{version}" => "ssgo_server")
     end
 end


### PR DESCRIPTION
Should fix #28 - I removed them because I didn't see the pattern in other formula.