### PR TITLE
Update ungoogled-chromium.rb

### DIFF
--- a/Formula/ungoogled-chromium.rb
+++ b/Formula/ungoogled-chromium.rb
@@ -4,7 +4,7 @@ class UngoogledChromium < Formula
     version "70.0.3538.110"
 
     url "https://dl.opendesktop.org/api/files/download/id/1542708876/s/53b09686e9e33f0677c8c1d702ec9a96b01a1a59ea8b31fdc5ea5cb4a919edfa2cc8aaa6e900fa27413e613cb03a3bd14f4b02eeed8948ec03ba6d562c13da23/t/1549787470/u//ungoogled-chromium_70.0.3538.110-1_linux.tar.xz"
-    sha256 "cda9460452a093ec506459944f2c77b50aa5b9e4fc0d1b64d1db1396344a5dc8"
+    sha256 "ba9be1cfe5dd52521c00771034aa0bfbf28716d0b175ba31062fa2b10944472a"
 
     bottle :unneeded
 


### PR DESCRIPTION
See https://ungoogled-software.github.io/ungoogled-chromium-binaries/
and these binaries are change their sha256 (not authenticity cannot be guaranteed).
So need CI+CD what will constantly check ```openssl sha256``` on the end-point url.
Can I fill issue with #Improvement #Suggestion tag about this?