### PR TITLE
Update zoom.rb

### DIFF
--- a/Formula/zoom.rb
+++ b/Formula/zoom.rb
@@ -1,10 +1,10 @@
 class Zoom < Formula
     desc "Video Conferencing, Web Conferencing, Webinars, Screen Sharing"
     homepage "https://zoom.us"
-    version "5.2.440215.0803"
+    version "5.6.13632.0328"
 
     url "https://zoom.us/client/latest/zoom_x86_64.tar.xz"
-    sha256 "f85e70bb5c1cbb0ee485000e1f2bfa3c89acbe15fa51865f9f8b91f8054841bc"
+    sha256 "7ed3b1610f80118649a93bddb017c954c9aa083c787cee9564cbb0cdf8f2c200"
 
     bottle :unneeded
 
@@ -26,3 +26,4 @@ class Zoom < Formula
         EOS
     end
 end
+

--- a/Formula/zoom.rb
+++ b/Formula/zoom.rb
@@ -8,14 +8,13 @@ class Zoom < Formula
 
     bottle :unneeded
 
-    depends_on "qt"
-
     def install
         libexec.install Dir["*"]
         (libexec/"zoom_brew_exec").write <<~EOS
             #!/usr/bin/env bash
-            cd $(brew --prefix zoom)/libexec
-            ./zoom
+            ZOOM_PATH=$(brew --prefix zoom)/libexec
+            cd $ZOOM_PATH
+            LD_LIBRARY_PATH=$ZOOM_PATH ./zoom
         EOS
         chmod(0755, "#{libexec}/zoom_brew_exec")
         bin.install_symlink("#{libexec}/zoom_brew_exec" => "zoom")

--- a/Formula/zoom.rb
+++ b/Formula/zoom.rb
@@ -1,12 +1,14 @@
 class Zoom < Formula
     desc "Video Conferencing, Web Conferencing, Webinars, Screen Sharing"
     homepage "https://zoom.us"
-    version "5.1.422789.0705"
+    version "5.2.440215.0803"
 
-    url "https://zoom.us/client/#{version}/zoom_x86_64.tar.xz"
-    sha256 "ae1c2faf6b31b114fe0131f0ffabdf007b20983a1123b37cef4bf7a63a2984e9"
+    url "https://zoom.us/client/latest/zoom_x86_64.tar.xz"
+    sha256 "f85e70bb5c1cbb0ee485000e1f2bfa3c89acbe15fa51865f9f8b91f8054841bc"
 
     bottle :unneeded
+
+    depends_on "qt"
 
     def install
         libexec.install Dir["*"]

--- a/Formula/zoom.rb
+++ b/Formula/zoom.rb
@@ -3,7 +3,7 @@ class Zoom < Formula
     homepage "https://zoom.us"
     version "5.6.13632.0328"
 
-    url "https://zoom.us/client/latest/zoom_x86_64.tar.xz"
+    url "https://zoom.us/client/#{version}/zoom_x86_64.tar.xz"
     sha256 "7ed3b1610f80118649a93bddb017c954c9aa083c787cee9564cbb0cdf8f2c200"
 
     bottle :unneeded


### PR DESCRIPTION
We must always choose zoom binary compiled with gcc greater-equal 4.7 (because LinuxBrew provided gcc is 5.5.0)
                           and provide latest `version` and its `sha256`.