### PR TITLE
fix: Update Jetbrains Toolbox and IntelliJ versions

### DIFF
--- a/Formula/intellij-idea-ce.rb
+++ b/Formula/intellij-idea-ce.rb
@@ -1,9 +1,9 @@
 class IntellijIdeaCe < Formula
     desc "The Most Intelligent Java IDE, community edition."
     homepage "http://www.jetbrains.com/idea/"
-    version "2018.1.4"
+    version "2022.2.3"
     url "https://download.jetbrains.com/idea/ideaIC-#{version}.tar.gz"
-    sha256 "26e674de05976cc7e822d77a2dfe8b8f6136e18f1e91f1c8212019f2781164e1"
+    sha256 "4ba5faafad48d58db5099fae080ae2238086d3d9803080082de8efe35d8bf4ed"
 
 
     def install

--- a/Formula/intellij-idea.rb
+++ b/Formula/intellij-idea.rb
@@ -3,7 +3,7 @@ class IntellijIdea < Formula
     homepage "http://www.jetbrains.com/idea/"
     version "2022.2.3"
     url "https://download.jetbrains.com/idea/ideaIU-#{version}.tar.gz"
-    sha256 "3866349090ea295c0ac4f1b77d20c74d8c9647e73e5ad541c61b3dfbfc4ab5f3"
+    sha256 "e1f9de8173cec9f7166894d66b82b89dee4da9022c05366d192f6112956184b3"
 
 
     def install

--- a/Formula/intellij-idea.rb
+++ b/Formula/intellij-idea.rb
@@ -1,7 +1,7 @@
 class IntellijIdea < Formula
     desc "The Most Intelligent Java IDE, ultimate edition."
     homepage "http://www.jetbrains.com/idea/"
-    version "2018.3.4"
+    version "2022.2.3"
     url "https://download.jetbrains.com/idea/ideaIU-#{version}.tar.gz"
     sha256 "3866349090ea295c0ac4f1b77d20c74d8c9647e73e5ad541c61b3dfbfc4ab5f3"
 

--- a/Formula/jetbrains-toolbox.rb
+++ b/Formula/jetbrains-toolbox.rb
@@ -11,7 +11,7 @@ class JetbrainsToolbox < Formula
         url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version}.tar.gz"
     end
 
-    sha256 "bb98b94fa714ca07db31ac5bb42fbba2eac610c360541848e59adf0f8d84cefb"
+    sha256 "97f519122d9522a1b240cbecfde07039b553986ae5554495be60ca6237adb580"
 
 
     def install

--- a/Formula/jetbrains-toolbox.rb
+++ b/Formula/jetbrains-toolbox.rb
@@ -1,7 +1,7 @@
 class JetbrainsToolbox < Formula
     desc "A control panel for your tools and projects."
     homepage "https://www.jetbrains.com/toolbox/app/"
-    version "1.8.3678"
+    version "1.26.1.13138
 
     option "with-no-cdn", "Download from https://download-cf.jetbrains.com directly. Use this if CDN's version is behind, which will cause a hash mismatch."
 


### PR DESCRIPTION
Previous versions were returning code 404 from their respective URLs.